### PR TITLE
Add additional check for prefix in route-target

### DIFF
--- a/src/main/fulcro/incubator/dynamic_routing.cljc
+++ b/src/main/fulcro/incubator/dynamic_routing.cljc
@@ -177,7 +177,7 @@
       (reduce (fn [result target-class]
                 (let [prefix (and target-class (route-target? target-class)
                                (some-> target-class (route-segment+) (matching-prefix path)))]
-                  (if (seq prefix)
+                  (if (and prefix (seq prefix))
                     (reduced {:matching-prefix prefix
                               :target          target-class})
                     result))) nil targets))))


### PR DESCRIPTION
If `route-target?` fails, it will return false, and so prefix will be false.
`(seq false)` will cause an error, so we need to guard against it.