### PR TITLE
Don't try to denormalize errors on pmutation result

### DIFF
--- a/src/main/fulcro/incubator/pessimistic_mutations.cljc
+++ b/src/main/fulcro/incubator/pessimistic_mutations.cljc
@@ -181,13 +181,12 @@
           {::keys [key target returning]} params
           mutation-response-key      (get-mutation-response-key params)
           mutation-response-swap-key (mutation-response-swap-keyword mutation-response-key)
-          mutation-response-swap     (let [data (get-in @state (conj ref mutation-response-swap-key))]
-                                       (if (prim/component-class? returning)
-                                         (prim/db->tree (prim/get-query returning) data @state)
-                                         data))
-          {::keys [status]} mutation-response-swap
+          {::keys [status] :as data} (get-in @state (conj ref mutation-response-swap-key))
+          api-error?                 (contains? data ::mutation-errors)
+          mutation-response-swap     (if (and (not api-error?) (prim/component-class? returning))
+                                       (prim/db->tree (prim/get-query returning) data @state)
+                                       data)
           hard-error?                (= status :hard-error)
-          api-error?                 (contains? mutation-response-swap ::mutation-errors)
           had-error?                 (or hard-error? api-error?)]
       (if had-error?
         (do

--- a/src/main/fulcro/incubator/pessimistic_mutations.cljc
+++ b/src/main/fulcro/incubator/pessimistic_mutations.cljc
@@ -183,11 +183,11 @@
           mutation-response-swap-key (mutation-response-swap-keyword mutation-response-key)
           {::keys [status] :as data} (get-in @state (conj ref mutation-response-swap-key))
           api-error?                 (contains? data ::mutation-errors)
-          mutation-response-swap     (if (and (not api-error?) (prim/component-class? returning))
-                                       (prim/db->tree (prim/get-query returning) data @state)
-                                       data)
           hard-error?                (= status :hard-error)
-          had-error?                 (or hard-error? api-error?)]
+          had-error?                 (or hard-error? api-error?)
+          mutation-response-swap     (if (and (not had-error?) (prim/component-class? returning))
+                                       (prim/db->tree (prim/get-query returning) data @state)
+                                       data)]
       (if had-error?
         (do
           (db.h/swap-entity! env assoc mutation-response-key (merge {::status :api-error} mutation-response-swap {::key key}))

--- a/src/workspaces/fulcro/incubator/pessimistic_mutations_ws.cljs
+++ b/src/workspaces/fulcro/incubator/pessimistic_mutations_ws.cljs
@@ -88,6 +88,8 @@
                                                  (do-something-good {})])} "Combo under ptransact!")
     (dom/button {:onClick #(pm/pmutate! this `do-something-bad {::pm/key :Sad-face})} "Mutation Crash/Hard network error")
     (dom/button {:onClick #(pm/pmutate! this `do-something-sorta-bad {::pm/key :Bummer})} "API Level Mutation Error")
+    (dom/button {:onClick #(pm/pmutate! this `do-something-sorta-bad {::pm/key :Bummer
+                                                                      ::pm/returning TodoList})} "API Level Mutation Error With Returning")
     (dom/button {:onClick #(pm/pmutate! this do-something-good-interface {::pm/returning TodoList
                                                                           ::pm/key       :todo-list-key
                                                                           ::pm/target    (df/multiple-targets


### PR DESCRIPTION
This PR fixes an issue that happens when `pmutate!` has a returning-key and returns an error. The previous code was blindly trying to denormalize any type of response with returning, but doing that with API errors end up swallowing the error message, breaking the error flow. This change check prevents an attempt to denormalization when the response contains an error.